### PR TITLE
Implemented pokemon_api.

### DIFF
--- a/web/modules/custom/pokemon_api/pokemon_api.module
+++ b/web/modules/custom/pokemon_api/pokemon_api.module
@@ -26,7 +26,7 @@ function pokemon_api_us_presave(EckEntityInterface $entity) {
   }
 
   // Define the file-path where data is to be stored.
-  $file_path = Utility::POKEMON_DIRECTORY . '/' . sprintf('%04d', $pokemon_number) . 'back_default.png';
+  $file_path = Utility::POKEMON_DIRECTORY . '/' . sprintf('%04d', $pokemon_number) . '/' . 'front_default.png';
 
   if (file_exists($file_path)) {
     return;

--- a/web/modules/custom/pokemon_api/src/Utils/Utility.php
+++ b/web/modules/custom/pokemon_api/src/Utils/Utility.php
@@ -2,8 +2,6 @@
 
 namespace Drupal\pokemon_api\Utils;
 
-use GuzzleHttp\Psr7\Request;
-
 /**
  * The Utility for pokemon api.
  */
@@ -83,9 +81,18 @@ class Utility {
   public static function getPokemonPhotoData(array $urls, int $pokemon_number): bool {
     $http_client = \Drupal::httpClient();
     foreach ($urls as $i => $o) {
-      $request = new Request('GET', $o);
-      $http_client
-        ->send($request, ['sink' => self::POKEMON_DIRECTORY . '/' . sprintf('%04d', $pokemon_number) . '/' . self::POKEMON_SPRITES[$i] . '.png']);
+      // Defined file path.
+      $file_path = self::POKEMON_DIRECTORY . '/' . sprintf('%04d', $pokemon_number) . '/' . self::POKEMON_SPRITES[$i] . '.png';
+
+      // Get image data.
+      $img_data = $http_client->get($o)
+        ->getBody()
+        ->getContents();
+      /**
+       * @var \Drupal\Core\File\FileSystem
+       */
+      $file_system_service = \Drupal::service('file_system');
+      $file_system_service->saveData($img_data, $file_path);
     }
     return TRUE;
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - ポケモンの正面画像を番号別のサブディレクトリに保存する機能を追加しました。

- **リファクタリング**
  - ポケモンの画像データ取得方法を改善し、HTTPリクエストの代わりにDrupalファイルシステムサービスを直接使用するように変更しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->